### PR TITLE
fix exception when balance with pool filter in a cluster with zero weight osds

### DIFF
--- a/placementoptimizer.py
+++ b/placementoptimizer.py
@@ -1262,7 +1262,7 @@ if args.mode == 'balance':
         enabled_crushclasses = set()
         for poolid in only_poolids:
             root_name = rootname_from_rule(crushrules[pools[poolid]['crush_rule']])
-            enabled_crushclasses |= {osds[osdid]['crush_class'] for osdid in candidates_for_root(root_name)}
+            enabled_crushclasses |= {osds[osdid]['crush_class'] for osdid in candidates_for_root(root_name) if osds[osdid]['weight'] != 0}
 
     osd_candidates = set()
     for crushclass in enabled_crushclasses:


### PR DESCRIPTION
There is an exception when balance with pool filter in a cluster which has zero weight osds (e.g. out):
```
# ./placementoptimizer.py balance --only-pool some-pool
Traceback (most recent call last):
  File "./placementoptimizer.py", line 1265, in <module>
    enabled_crushclasses |= {osds[osdid]['crush_class'] for osdid in candidates_for_root(root_name)}
  File "./placementoptimizer.py", line 1265, in <setcomp>
    enabled_crushclasses |= {osds[osdid]['crush_class'] for osdid in candidates_for_root(root_name)}
KeyError: 'crush_class'
```