### PR TITLE
Cancel Backfills and keeps upmaps

### DIFF
--- a/cancel_backfill.py
+++ b/cancel_backfill.py
@@ -1,0 +1,83 @@
+#!/usr/bin/env python3
+
+from subprocess import DEVNULL, check_output
+from json import loads
+
+from setuptools import Command
+
+def jsoncall(cmd, swallow_stderr=False):
+    if not isinstance(cmd, list):
+        raise ValueError("need cmd as list")
+    stderrval = DEVNULL if swallow_stderr else None
+    rawdata = check_output(cmd, stderr=stderrval)
+    return loads(rawdata.decode())
+
+def get_osd_dump():
+    command = "ceph osd dump -f json".split()
+    return jsoncall(command)
+
+def get_pg_query(pgid):
+    command = f"ceph pg {pgid} query -f json".split()
+    return jsoncall(command)
+
+def find_remapped_list(osd_dump):
+    pg_upmap_items = {}
+    pg_with_upmap = [x['pgid'] for x in osd_dump["pg_temp"]]
+    for item in osd_dump["pg_upmap_items"]:
+        if item['pgid'] in pg_with_upmap:
+            osds = item["mappings"]
+            remapped_list_for_osd = {"map" : [], "stats" : ""}
+            for osd in osds:
+                remapped_list_for_osd["map"].append(
+                    (osd['from'], osd['to'])
+                )
+            pg_upmap_items[item['pgid']] = remapped_list_for_osd
+    return pg_upmap_items
+
+def find_current_remapped_pg(pg_upmap_items):
+    for pg in pg_upmap_items:
+        pg_detail = get_pg_query(pg)
+        for up, act in zip(pg_detail["up"], pg_detail["acting"]):
+            if up != act:
+                pg_upmap_items[pg]["map"].append((up,act))
+        pg_upmap_items[pg]["stats"] = pg_detail["state"]
+
+def main():
+    osd_dump = get_osd_dump()
+    pg_upmap_items = find_remapped_list(osd_dump)
+    find_current_remapped_pg(pg_upmap_items)
+    
+    active_backfill = []
+    waiting_backfill= []
+
+    for item in pg_upmap_items:
+        if pg_upmap_items[item]['stats'] == "active+remapped+backfilling":
+            active_backfill.append(
+                "ceph osd pg-upmap-items %s %s"
+                %(
+                    item,
+                    " ".join(f"{x} {y}" for x,y in pg_upmap_items[item]["map"]),
+                )
+            )
+        elif pg_upmap_items[item]['stats'] == "active+remapped+backfill_wait":
+            waiting_backfill.append(
+                "ceph osd pg-upmap-items %s %s"
+                %(
+                    item,
+                    " ".join(f"{x} {y}" for x,y in pg_upmap_items[item]["map"]),
+                )
+            )
+
+    if active_backfill:
+        print("----  ACTIVE  ----")
+        for item in active_backfill:
+            print(item)
+
+    if waiting_backfill:
+        print("----  WAIT  ----")
+        for item in waiting_backfill:
+            print(item)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
output example:

```sh
root@TEST:/SRE# python3 cancel_backfill.py 
----  ACTIVE  ----
ceph osd pg-upmap-items 9.29e 172 219 95 212 18 132 157 175 55 216 38 37
ceph osd pg-upmap-items 9.db7 74 203 128 86 238 137 88 204 95 54 245 251
ceph osd pg-upmap-items 9.e1b 143 13 17 147 194 12 93 102 35 14 114 110
----  WAIT  ----
ceph osd pg-upmap-items 9.68 104 140 38 48
ceph osd pg-upmap-items 9.354 66 95 16 163 202 237 219 109 240 13 38 185
ceph osd pg-upmap-items 9.45b 113 252 112 85 258 200 59 157 38 201
ceph osd pg-upmap-items 9.507 71 153 148 130 163 85 246 55 51 6 114 102
ceph osd pg-upmap-items 9.51d 69 12 212 45 20 195 252 14 141 239 114 205
ceph osd pg-upmap-items 9.a37 160 36 113 79 22 175 184 90 114 122
root@TEST:/SRE# ./op.py showremapped
pg 9.e1b           backfill  40.7G: 109313 of 208852, 52.3%, 110->114
pg 9.db7           backfill  40.5G: 108060 of 208637, 51.8%, 251->245
pg 9.51d           waiting   40.6G: 0 of 208872, 0.0%, 205->114
pg 9.507           waiting   40.8G: 0 of 209150, 0.0%, 102->114
pg 9.45b           waiting   40.9G: 0 of 209550, 0.0%, 201->38
pg 9.354           waiting   40.7G: 0 of 209366, 0.0%, 185->38
pg 9.68            waiting   40.8G: 0 of 208257, 0.0%, 48->38
pg 9.29e           backfill  40.8G: 61704 of 208935, 29.5%, 37->38
pg 9.a37           waiting   41.2G: 0 of 209077, 0.0%, 122->114
```