### PR TITLE
Fix: prevent crash when osd has no device class.

### DIFF
--- a/placementoptimizer.py
+++ b/placementoptimizer.py
@@ -632,11 +632,15 @@ def bucket_fill(id, parent_id=None):
 
         else:
             # it's a device
+            if "class" in child:
+               dev_class = child["class"]
+            else:
+               dev_class = ""
             new_node = {
                 "id": cid,
                 "name": child["name"],
                 "type_name": "osd",
-                "class": child["class"],
+                "class": dev_class,
                 "parent": id,
             }
             ids[cid] = new_node


### PR DESCRIPTION
```
./placementoptimizer.py -v balance --max-pg-moves 10 | tee /tmp/balance-upmaps
[2022-09-08 13:53:26,047] gathering cluster state via ceph api...
Traceback (most recent call last):
  File "./placementoptimizer.py", line 650, in <module>
    bucket_tree, bucket_ids = bucket_fill(root_bucket_id)
  File "./placementoptimizer.py", line 629, in bucket_fill
    new_nodes, new_ids = bucket_fill(cid, id)
  File "./placementoptimizer.py", line 639, in bucket_fill
    "class": child["class"],
KeyError: 'class'
```