### PR TITLE
Verify if node is osd while navigating crush tree

### DIFF
--- a/placementoptimizer.py
+++ b/placementoptimizer.py
@@ -2215,7 +2215,8 @@ class ClusterState:
         for node in self.state["osd_df_tree_dump"]["nodes"]:
             if node['type'] == "host":
                 for osdid in node['children']:
-                    self.osds[osdid]["host_name"] = node['name']
+                    if node['type'] == "osd":
+                        self.osds[osdid]["host_name"] = node['name']
 
 
         # crush infos


### PR DESCRIPTION
It is not guaranteed that only OSDs reside under a host and this verifies that only OSD children are assigned a host_name

Edge-case found in this crush hierarchy

- host X
  - chassis Y (external enclosure)
    - osd Z