### PR TITLE
Include OMAP size in device usage calculation

### DIFF
--- a/placementoptimizer.py
+++ b/placementoptimizer.py
@@ -2079,7 +2079,7 @@ class ClusterState:
             statfs = osd_stat['statfs']
             self.osds[osdid].update({
                 "device_size": statfs["total"],
-                "device_used": statfs["allocated"] + statfs["internal_metadata"],
+                "device_used": statfs["allocated"] + statfs["internal_metadata"] + statfs["omap_allocated"],
                 "device_used_data": statfs["allocated"],
                 "device_used_meta": statfs["internal_metadata"],
                 "device_used_omap": statfs["omap_allocated"],


### PR DESCRIPTION
Take into account the size of the OMAP data when calculating the device usage of an OSD that enters the optimization.

Here is an example of the effect of the proposed change on the distribution of the OSD usage over time. The bands show the OSD distribution ranges

- percentile 10-90: highest opacity (between the `ssd p10` and `ssd p90` legend entries)
- percentile 1-99: medium opacity (between the `ssd p01` and `ssd p99` legend entries)
- min-max: lowest opacity (between the `ssd min` and `ssd max` legend entries)

The balancer was running in a loop acting on 10 PGs at a time with a 2 min cooldown throughout the entire shown period except ca. 4 hours starting 2025-03-06 at 16:00. The balancer was updated and started again on 2025-03-06 at 20:00 as shown by the tooltip on this screen shot:

<img width="1377" alt="jj-balancer-omap-update" src="https://github.com/user-attachments/assets/f66b84e6-9fba-41cb-bd7f-a320975ff2bf" />

The shown cluster has a pool with significant OMAP data volume. An example of an application and workload leading to such a situation is mentioned in [1].

Before the update, the balancer was ignoring some of the fullest OSDs. Here's the list of the top 15 fullest OSDs of the SSD device class:

```Shell
ceph osd df class ssd | (head -n1; awk '($4==1.0 && $20=="up"){print $0}' | sort -rnk17 | head -n15)
```

```console
ID    CLASS  WEIGHT   REWEIGHT  SIZE     RAW USE  DATA     OMAP     META     AVAIL     %USE   VAR   PGS  STATUS
 546    ssd  1.74660   1.00000  1.7 TiB  1.4 TiB  1.1 TiB  202 GiB   45 GiB   368 GiB  79.41  1.18   39      up
 616    ssd  3.49309   1.00000  3.5 TiB  2.6 TiB  2.3 TiB  252 GiB   55 GiB   906 GiB  74.68  1.11   80      up
 548    ssd  1.74660   1.00000  1.7 TiB  1.3 TiB  1.1 TiB  121 GiB   19 GiB   475 GiB  73.46  1.09   38      up
 622    ssd  3.49309   1.00000  3.5 TiB  2.6 TiB  2.3 TiB  184 GiB   36 GiB   953 GiB  73.35  1.09   77      up
 332    ssd  1.74660   1.00000  1.7 TiB  1.3 TiB  1.1 TiB  122 GiB   18 GiB   478 GiB  73.30  1.09   40      up
 630    ssd  3.49309   1.00000  3.5 TiB  2.6 TiB  2.3 TiB  234 GiB   51 GiB   956 GiB  73.27  1.09   76      up
 337    ssd  1.74660   1.00000  1.7 TiB  1.3 TiB  1.1 TiB  115 GiB   20 GiB   479 GiB  73.23  1.09   38      up
 490    ssd  1.74660   1.00000  1.7 TiB  1.3 TiB  1.1 TiB  114 GiB   20 GiB   481 GiB  73.11  1.09   39      up
  50    ssd  2.91089   1.00000  2.9 TiB  2.1 TiB  1.9 TiB  141 GiB   31 GiB   813 GiB  72.73  1.08   65      up
  47    ssd  1.74660   1.00000  1.7 TiB  1.3 TiB  1.1 TiB  154 GiB   37 GiB   488 GiB  72.69  1.08   36      up
 552    ssd  1.74660   1.00000  1.7 TiB  1.3 TiB  1.1 TiB  136 GiB   12 GiB   494 GiB  72.37  1.08   43      up
 492    ssd  1.74660   1.00000  1.7 TiB  1.3 TiB  1.1 TiB   98 GiB   19 GiB   499 GiB  72.10  1.07   37      up
 494    ssd  1.74660   1.00000  1.7 TiB  1.3 TiB  1.1 TiB  133 GiB   16 GiB   500 GiB  72.05  1.07   40      up
 495    ssd  1.74660   1.00000  1.7 TiB  1.3 TiB  1.1 TiB   98 GiB   18 GiB   501 GiB  71.97  1.07   37      up
 624    ssd  3.49309   1.00000  3.5 TiB  2.5 TiB  2.3 TiB  154 GiB   43 GiB  1012 GiB  71.71  1.07   74      up
```

When asked to move a single PG, the balancer didn't even consider these OSDs because of the lack of OMAP data in its evaluation:

```shell
./placementoptimizer.py -vvv balance \
    --max-pg-moves 1 \
    --max-move-attempts 50 \
    --osdused delta \
    --osdfrom fullest \
    --only-poolid 12 \
    --ignore-ideal-pgcounts all
```

```console
[2025-03-06 13:27:04,591] gathering cluster state via ceph api...
[2025-03-06 13:27:48,933] Cluster topology changed during information gathering (e.g. a pg changed state). Wait for things to calm down and try again
[2025-03-06 13:27:50,364] running pg balancer
[2025-03-06 13:27:50,364] only considering pools {12}
[2025-03-06 13:27:50,861] cluster variance for crushclasses:
[2025-03-06 13:27:50,862]               ssd: 2.260
[2025-03-06 13:27:50,862] usable space, caused by osd
[2025-03-06 13:27:50,862]   pool                                avail limitosd
[2025-03-06 13:27:50,862]   foobar.blob.0                     103.17T     2913
[2025-03-06 13:27:50,862] OSD fill rate by crushclass:
[2025-03-06 13:27:50,862]   ssd: average=65.91%, unconstrained=67.17%
[2025-03-06 13:27:50,862]       min osd.336   61.273%
[2025-03-06 13:27:50,862]    median osd.2424  65.974%
[2025-03-06 13:27:50,862]       max osd.2913  69.466%
[2025-03-06 13:27:50,862] trying to empty osd.2913 (69.465687 %)
[2025-03-06 13:27:50,862] TRY-0 moving pg 12.1319 (1/59) with 34.6G from osd.2913
[2025-03-06 13:27:50,862] movecheck for pg 12.1319 on [2913, 2438, 1624] (poolsize=3)
[2025-03-06 13:27:50,862]   OK => taking pg 12.1319 from source osd.2913,  pool=12 count 59, ideal 55.75676269733824
[2025-03-06 13:27:50,863] prepare crush check for pg 12.1319 currently up=[2913, 2438, 1624]
[2025-03-06 13:27:50,863] rule:
{'name': 'replicated-default-ssd',
 'steps': [{'item': -54, 'item_name': 'default~ssd', 'op': 'take'},
           {'num': 0, 'op': 'chooseleaf_firstn', 'type': 'host'},
           {'op': 'emit'}]}
[2025-03-06 13:27:50,863] allowed reuses per rule step, starting at root: [[3, 1, 1]]
[2025-03-06 13:27:50,863] processing crush step {'op': 'take', 'item': -54, 'item_name': 'default~ssd'} with tree_depth=0, rule_step=0, item_uses=defaultdict(<class 'dict'>, {})
[2025-03-06 13:27:50,863]    trace for 2913: [{'id': -54, 'type_name': 'root'}, {'id': -339, 'type_name': 'host'}, {'id': 2913, 'type_name': 'osd'}]
[2025-03-06 13:27:50,863]    trace for 2438: [{'id': -54, 'type_name': 'root'}, {'id': -294, 'type_name': 'host'}, {'id': 2438, 'type_name': 'osd'}]
[2025-03-06 13:27:50,863]    trace for 1624: [{'id': -54, 'type_name': 'root'}, {'id': -234, 'type_name': 'host'}, {'id': 1624, 'type_name': 'osd'}]
[2025-03-06 13:27:50,863] processing crush step {'op': 'chooseleaf_firstn', 'num': 0, 'type': 'host'} with tree_depth=0, rule_step=1, item_uses=defaultdict(<class 'dict'>, {0: {-54: 3}})
[2025-03-06 13:27:50,863] processing crush step {'op': 'emit'} with tree_depth=1, rule_step=2, item_uses=defaultdict(<class 'dict'>, {0: {-54: 3}, 1: {-339: 1, -294: 1, -234: 1}})
[2025-03-06 13:27:50,863] crush check preparation done: rule_tree_depth=[0, 1, 2] item_uses=defaultdict(<class 'dict'>, {0: {-54: 3}, 1: {-339: 1, -294: 1, -234: 1}, 2: {2913: 1, 2438: 1, 1624: 1}})
[2025-03-06 13:27:50,865] TRY-1 move 12.1319 osd.2913 => osd.336
[2025-03-06 13:27:50,865]  OK => osd.336 has pool=12 30, target 33.46440698290034
[2025-03-06 13:27:50,865]    trace for old osd.2913: [{'id': -54, 'type_name': 'root'}, {'id': -339, 'type_name': 'host'}, {'id': 2913, 'type_name': 'osd'}]
[2025-03-06 13:27:50,865]    trace for new osd.336: [{'id': -54, 'type_name': 'root'}, {'id': -81, 'type_name': 'host'}, {'id': 336, 'type_name': 'osd'}]
[2025-03-06 13:27:50,865]    item reuse check ok:   osd.2913@[0]=-54 -> osd.336@[0]=-54 x uses=3 <= max_allowed=3
[2025-03-06 13:27:50,865]    item reuse check ok:   osd.2913@[1]=-339 -> osd.336@[1]=-81 x uses=1 <= max_allowed=1
[2025-03-06 13:27:50,865]    item reuse check ok:   osd.2913@[2]=2913 -> osd.336@[2]=336 x uses=1 <= max_allowed=1
[2025-03-06 13:27:50,865] recording move of pg=12.1319 from 2913->336
[2025-03-06 13:27:50,867]   SAVE move 12.1319 osd.2913 => osd.336
[2025-03-06 13:27:50,867]     props: size=34.6G remapped=False upmaps=0
[2025-03-06 13:27:50,867]     pg 12.1319 was on [2913, 2438, 1624]
[2025-03-06 13:27:50,867]     pg 12.1319 now on [336, 2438, 1624]
[2025-03-06 13:27:50,867]     => variance new=2.212309 < 2.259671=old
[2025-03-06 13:27:50,867] cluster variance for crushclasses:
[2025-03-06 13:27:50,867]               ssd: 2.212
[2025-03-06 13:27:50,867] usable space, caused by osd
[2025-03-06 13:27:50,867]   pool                                avail limitosd
[2025-03-06 13:27:50,867]   foobar.blob.0                     103.82T     3418
[2025-03-06 13:27:50,867] OSD fill rate by crushclass:
[2025-03-06 13:27:50,867]   ssd: average=65.91%, unconstrained=67.17%
[2025-03-06 13:27:50,867]       min osd.558   61.506%
[2025-03-06 13:27:50,867]    median osd.2424  65.974%
[2025-03-06 13:27:50,867]       max osd.3418  69.312%
[2025-03-06 13:27:50,867] enough remaps found
[2025-03-06 13:27:50,867] --------------------------------------------------------------------------------
[2025-03-06 13:27:50,867] generated 1 remaps in 1 steps.
[2025-03-06 13:27:50,867] total movement size: 34.6G
[2025-03-06 13:27:50,868] --------------------------------------------------------------------------------
[2025-03-06 13:27:50,868] OSD fill rate by crushclass:
[2025-03-06 13:27:50,868]                       OLD                         NEW
[2025-03-06 13:27:50,868]   ssd:
[2025-03-06 13:27:50,868]       raw            67.172%                     67.172%
[2025-03-06 13:27:50,868]       avg            65.912%                     65.913%
[2025-03-06 13:27:50,868]  variance             2.260                       2.212
[2025-03-06 13:27:50,868]       min osd.336    61.273%          osd.558    61.506%
[2025-03-06 13:27:50,868]    median osd.2424   65.974%          osd.2424   65.974%
[2025-03-06 13:27:50,868]       max osd.2913   69.466%          osd.3418   69.312%
[2025-03-06 13:27:50,868]
[2025-03-06 13:27:50,868] new usable space:
[2025-03-06 13:27:50,868]   pool name                          id previous         new      change
[2025-03-06 13:27:50,868]   foobar.blob.0                      12  103.17T ->  103.82T =>  662.77G
[2025-03-06 13:27:50,868]                                                            sum:  662.77G
[2025-03-06 13:27:50,868] --------------------------------------------------------------------------------
ceph osd pg-upmap-items 12.1319 2913 336
```

This was fixed after the update as demonstrated by the change in the width of the band representing the OSD usage spread. This width giving the difference between the maximum and minimum utilization shrank from 74.6% - 64.9% = 10.7% on 2025-03-06 20:00 to 68.5% - 66.5% = 2.0% within 7 hours and then permanently stayed at this same narrow width of +/- 1% around the average utilization.

[1] [The Challenge of Storing Small Objects on a Large Scale - Luis Domingues & Ján Senko, Proton AG](https://ceph2024.sched.com/event/1kzKr/the-challenge-of-storing-small-objects-on-a-large-scale-luis-domingues-jan-senko-proton-ag#), talk at the [Cephalocon 2024](https://ceph2024.sched.com), Slide 7 of [the presentation](https://static.sched.com/hosted_files/ceph2024/10/proton_jan_luis.pdf)