### PR TITLE
Add `--unsafe` Option

### DIFF
--- a/placementoptimizer.py
+++ b/placementoptimizer.py
@@ -42,7 +42,7 @@ def parse_args():
                      help="decrease program verbosity")
     cli.add_argument("--profile", action="store_true",
                      help=("activate the performance profiler for the balancer itself"))
-    cli.add_argument("--unsafe", action="store_true",
+    cli.add_argument("--unsafe-gather", action="store_true",
                      help="ignore epoch changes during cluster state gathering")
 
     sp = cli.add_subparsers(dest='mode')
@@ -803,15 +803,15 @@ class ClusterState:
 
     def __init__(self, statefile: Optional[str] = None,
                  osdsize_method: OSDSizeMethod = OSDSizeMethod.CRUSH,
-                 ceph_command: str = "ceph", safe=True):
+                 ceph_command: str = "ceph", safe_gather=True):
         self._ceph_command: str = ceph_command
 
         self.state: Dict[str, Any] = dict()
-        self.load(statefile, safe)
+        self.load(statefile, safe_gather)
 
         self.osdsize_method = osdsize_method
 
-    def load(self, statefile: Optional[str], safe=True):
+    def load(self, statefile: Optional[str], safe_gather=True):
         # use cluster state from a file
         if statefile:
             logging.info(f"loading cluster state from file {statefile}...")
@@ -854,10 +854,12 @@ class ClusterState:
 
             # check if the osdmap version changed meanwhile
             # => we'd have inconsistent state
-            if safe and self.state['osd_dump']['epoch'] != jsoncall(f"{self._ceph_command} osd dump --format json".split())['epoch']:
+            if safe_gather and self.state['osd_dump']['epoch'] != jsoncall(f"{self._ceph_command} osd dump --format json".split())['epoch']:
                 raise RuntimeError("Cluster osdmap epoch changed during information gathering (e.g. a pg changed state). "
                                    "Wait for things to calm down and try again - "
-                                   "or implement/request a transactional state dump feature for Ceph.")
+                                   "or implement/request a transactional state dump feature for Ceph. "
+                                   "Alternatively, use the `--unsafe-gather` option if you're OK "
+                                   "with taking the risk of using an inconsistent cluster state.")
 
     def dump(self, output_file):
         logging.info(f"cluster state dumped. now saving to {output_file}...")
@@ -5534,7 +5536,7 @@ def main():
         return 1 if failed > 0 else 0
 
     elif args.mode == 'gather':
-        state = ClusterState(ceph_command=args.ceph_command, safe=not args.unsafe)
+        state = ClusterState(ceph_command=args.ceph_command, safe_gather=not args.unsafe_gather)
         state.dump(args.output_file)
 
     else:
@@ -5551,7 +5553,7 @@ def main():
         else:
             raise RuntimeError(f"unknown osd weight method {args.osdsize!r}")
 
-        state = ClusterState(args.state, osdsize_method=osdsize_method, ceph_command=args.ceph_command, safe=not args.unsafe)
+        state = ClusterState(args.state, osdsize_method=osdsize_method, ceph_command=args.ceph_command, safe_gather=not args.unsafe_gather)
         state.preprocess()
 
         if args.mode == 'balance':


### PR DESCRIPTION
The bigger a cluster the longer the state gathering takes and the more frequently PG states change and new epochs are generated. At some point it eventually becomes impossible to gather the consistent state with no epoch changes. It's still useful to be able to run the balancer in such situations despite it being unsafe because most of the inconsistencies have no effect on the balancer output like e.g. PGs entering and exiting the `scrubbing` and/or `deep`.