### PR TITLE
Add UTF-8 Encoding 

### DIFF
--- a/placementoptimizer.py
+++ b/placementoptimizer.py
@@ -5523,7 +5523,6 @@ def repairstats(args, cluster):
 
 
 def main():
-    import io
     if sys.stdout.encoding.lower() != 'utf-8':
         sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
         sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')

--- a/placementoptimizer.py
+++ b/placementoptimizer.py
@@ -5523,6 +5523,11 @@ def repairstats(args, cluster):
 
 
 def main():
+    import io
+    if sys.stdout.encoding.lower() != 'utf-8':
+        sys.stdout = io.TextIOWrapper(sys.stdout.buffer, encoding='utf-8')
+        sys.stderr = io.TextIOWrapper(sys.stderr.buffer, encoding='utf-8')
+
     args = parse_args()
     level = args.verbose - args.quiet
 


### PR DESCRIPTION
Added UTF-8 encoding wrapper for stdout/stderr at the start of main() to prevent UnicodeEncodeError when printing Unicode characters (e.g., delta symbol) in cephadm shell environments.

- When using cephadm shell - environments frequently have non-UTF-8 default encodings (ASCII)
- Often cephadm shell is invoked fresh for each monitoring/cluster session, environment-level encoding configuration is not practical
- Python's default print behavior respects sys.stdout.encoding, causing crashes when outputting Unicode symbols outside the shell's default codepage.

Error spotted when listing remapped placement groups by OSD: 
```
./placementoptimizer.py remap show --by-osd

Traceback (most recent call last):
  File "./placementoptimizer.py", line 5624, in <module>
    exit(main())
  File "./placementoptimizer.py", line 5618, in main
    run()
  File "./placementoptimizer.py", line 5577, in <lambda>
    run = lambda: show_remapped(args, state)
  File "./placementoptimizer.py", line 5427, in show_remapped
    print(f"{osdname}: {osdparent}  =>{sum_to} {sum_data_to_pp} <={sum_from} {sum_data_from_pp}"
UnicodeEncodeError: 'ascii' codec can't encode character '\u0394' in position 41: ordinal not in range(128)
```

Fixed with adding environment variable:
```
export PYTHONIOENCODING=utf-8
./placementoptimizer.py remap show --by-osd
```
However this becomes impractical when launching cephadm shell for each session.

Code [line](https://github.com/TheJJ/ceph-balancer/blob/master/placementoptimizer.py#L5428) causing this UnicodeEncodeError:
```
print(f"{osdname}: {osdparent}  =>{sum_to} {sum_data_to_pp} <={sum_from} {sum_data_from_pp}"
      f" (\N{Greek Capital Letter Delta}{sum_data_delta_pp}) {fullness}")
```

I know Python environment setup issues should not be reflected in code changes however with the current PR this will just work out of the box:

```
echo $PYTHONIOENCODING

./placementoptimizer.py remap show --by-osd
osd.5: node-1  =>0 0.0B <=1 36.55G (Δ36.55G)   drive=49.4% 9.05T/18.32T  crush=49.4% 9.05T/18.32T
  <-36.3e2          backfill  36.5G    5<-8    32312 of 46926, 68.9%

osd.7: node-1  =>0 0.0B <=1 36.46G (Δ36.46G)   drive=49.4% 9.05T/18.32T  crush=49.4% 9.05T/18.32T
  <-36.1cf          backfill  36.5G    7<-8    33442 of 46829, 71.4%
...
```