### PR TITLE
Fix UnboundLocalError in preprocess for empty incoming PGs

### DIFF
--- a/placementoptimizer.py
+++ b/placementoptimizer.py
@@ -2167,6 +2167,12 @@ class ClusterState:
 
                 shardsize = self.get_pg_shardsize(pg_incoming)
 
+                # this osd has shards of the pg.
+                # initialised here (not in the else-branch below) so the
+                # `missing_shards_size` calculation outside the if/else is
+                # always defined, including when pg_objs <= 0.
+                pg_shards_on_osd = 0
+
                 if pg_objs <= 0:
                     osd_shards_objs_size_transferred = 0
 
@@ -2209,8 +2215,6 @@ class ClusterState:
                     pg_degraded_shards_on_osd = 0
                     # this osd is the target of a pg move where the source does exist
                     pg_misplaced_shards_on_osd = 0
-                    # this osd has shards of the pg
-                    pg_shards_on_osd = 0
 
                     # get the real current remaps active in the cluster
                     incoming_pg_moves = self.get_remaps(pginfo)


### PR DESCRIPTION
Symptom: balance aborts during state preprocessing with

    File "placementoptimizer.py", line 2271, in preprocess
        missing_shards_size = (shardsize * pg_shards_on_osd) - osd_shards_objs_size_transferred
    UnboundLocalError: local variable 'pg_shards_on_osd' referenced before assignment

Root cause: `pg_shards_on_osd` is initialised inside the `else` branch of `if pg_objs <= 0`, but the `missing_shards_size` calculation that reads it lives outside the if/else. When an incoming PG has zero objects (freshly created or just-emptied PG that is still being remapped), the if-branch is taken, the else-branch never runs, and the variable is never bound.

Fix: hoist `pg_shards_on_osd = 0` above the if/else. The else-branch still increments it inside the remap loop; the if-branch leaves it at 0, which is correct for an empty incoming transfer (`missing_shards_size = shardsize * 0 - 0 = 0`).

Just to be clear, this is one of three AI generated fixes. I collected these three issues over the last few months and wanted to see if claude could find sensible fixes and it looked good to me. If you don't like this, I won't do this again.