### PR TITLE
Fix moves_from_up_acting crash when acting set is wider than up

### DIFF
--- a/placementoptimizer.py
+++ b/placementoptimizer.py
@@ -607,6 +607,9 @@ def moves_from_up_acting(up_osds: List[int],
     >>> moves_from_up_acting(up_osds=[1, 2, 3, 4], acting_osds=[3, 2], is_ec=False)
     [((-1, -1), (1, 4))]
 
+    >>> moves_from_up_acting(up_osds=[3, 2], acting_osds=[1, 2, 3, 4], is_ec=False)
+    [((1, 4), (-1, -1))]
+
     """
 
     moves: List[Tuple[Tuple[int, ...], Tuple[int, ...]]] = list()
@@ -626,8 +629,14 @@ def moves_from_up_acting(up_osds: List[int],
         # all that are acting but don't stay in up.
         from_osds = list(actings - ups)
 
+        # pad the shorter side with -1 sentinels so |from| == |to|.
+        # the acting set can be wider than up (e.g. recovery, pool size shrink,
+        # temporary mappings) — the original code only handled the opposite case.
         missing_osds = len(to_osds) - len(from_osds)
-        from_osds.extend([-1] * missing_osds)
+        if missing_osds > 0:
+            from_osds.extend([-1] * missing_osds)
+        elif missing_osds < 0:
+            to_osds.extend([-1] * -missing_osds)
 
         if not len(from_osds) == len(to_osds):
             raise Exception(f"|from| != |to|: |{from_osds}| != |{to_osds}|")


### PR DESCRIPTION
Symptom: balance aborts with

    File "placementoptimizer.py", line 633, in moves_from_up_acting
        raise Exception(f"|from| != |to|: |{from_osds}| != |{to_osds}|")
    Exception: |from| != |to|: |[24, 33, 41]| != |[9, 21]|

triggered from ClusterState.preprocess via get_remaps whenever a replicated PG's acting set is currently wider than its up set (recovery, pool size shrink, temp mappings).

Root cause: the symmetric padding was only half-implemented. The code computed `missing_osds = len(to_osds) - len(from_osds)` and then did `from_osds.extend([-1] * missing_osds)`, which is a no-op when `missing_osds` is negative. The function's own doctest at line 607 documents the symmetric case (`up=[1,2,3,4], acting=[3,2]` produces `[((-1, -1), (1, 4))]`), so the intent was always to pad whichever side is shorter — only one direction was wired up.

Fix: pad to_osds with -1 sentinels when from_osds is the longer side, mirroring the existing branch. Add a doctest covering the previously broken direction.

Just to be clear, this is one of three AI generated fixes. I collected these three issues over the last few months and wanted to see if claude could find sensible fixes and it looked good to me. If you don't like this, I won't do this again.