### PR TITLE
Skip undersized PGs in balance() instead of aborting the run

### DIFF
--- a/placementoptimizer.py
+++ b/placementoptimizer.py
@@ -4806,7 +4806,16 @@ def balance(args, cluster):
                 move_pg_shardsize = pg_candidates.get_size(move_pg)
                 logging.debug("TRY-0 moving pg %s (%s/%s) with %s from osd.%s", move_pg, move_pg_idx+1, len(pg_candidates), pformatsize(move_pg_shardsize), osd_from)
 
-                try_pg_move = PGMoveChecker(pg_mappings, move_pg)
+                # an undersized PG (its up set is shorter than pool_size,
+                # e.g. CRUSH could not place all shards) makes PGMoveChecker
+                # raise — skip those candidates instead of aborting the whole
+                # balance run. The shard must be recovered by Ceph before any
+                # planned upmap is meaningful anyway.
+                try:
+                    try_pg_move = PGMoveChecker(pg_mappings, move_pg)
+                except RuntimeError as exc:
+                    logging.debug("SKIP pg %s from osd.%s: %s", move_pg, osd_from, exc)
+                    continue
                 osd_to_candidates = [
                     osdid
                     for osdid in try_pg_move.get_osd_candidates(osd_from)


### PR DESCRIPTION
Symptom: balance aborts on the first undersized PG it considers as a move candidate with

    File "placementoptimizer.py", line 2702, in __init__
        raise RuntimeError(f"not as many roots as shards! root_order={root_order} osds={self.pg_osds}")
    RuntimeError: not as many roots as shards! root_order=['default~nvme', 'default~nvme', 'default~nvme'] osds=[32, 4]

raised from PGMoveChecker.__init__ via balance() at line 4809.

Root cause: PGMappings populates `self.pg_mappings[pgid]` directly from `pginfo["up"]` without normalising its length against `pool_size`. When CRUSH cannot place all shards (host failure, exhausted candidates, etc.), the up set is shorter than pool_size, so `len(pg_osds) != len(root_order)` and PGMoveChecker raises. The exception propagates up and kills the whole balance run.

Fix: catch RuntimeError around the PGMoveChecker construction in balance() and `continue` to the next candidate, mirroring the existing skip pattern used for other unmovable candidates a few lines above. Recovering an undersized PG is Ceph's job — moving its remaining shards via upmap is unsafe to plan against, so skipping is the correct behaviour.

Just to be clear, this is one of three AI generated fixes. I collected these three issues over the last few months and wanted to see if claude could find sensible fixes and it looked good to me. If you don't like this, I won't do this again.