### PR TITLE
fix: remap undo target and source osds

### DIFF
--- a/placementoptimizer.py
+++ b/placementoptimizer.py
@@ -5467,17 +5467,23 @@ def undo_remapped(args, cluster) -> None:
 
     source_osdids = None
     if args.source_osds:
-        source_osdids = {int(osdid) for osdid in args.osds.split(" ")}
+        source_osdids = {int(osdid) for osdid in args.source_osds.split(" ")}
 
     target_osdids = None
     if args.target_osds:
-        target_osdids = {int(osdid) for osdid in args.osds.split(" ")}
+        target_osdids = {int(osdid) for osdid in args.target_osds.split(" ")}
+
+    only_on_osdids = None
+    if args.only_on_osds:
+        only_on_osdids = {int(osdid) for osdid in args.only_on_osds.split(" ")}
 
     for pgid, pginfo in cluster.pgs.items():
         pgstate = pginfo["state"].split("+")
         if "remapped" not in pgstate:
             continue
         if args.exclude_backfilling and "backfilling" in pgstate:
+            continue
+        if only_on_osdids and not (set(pginfo["acting"]) & only_on_osdids):
             continue
 
         for osds_from, osds_to in cluster.get_remaps(pginfo):


### PR DESCRIPTION
When running remap undo, using the --source-osds and --target-osds filters will cause problems because the code uses args.osds, which is not present in this file. This part is probably copied from remap show and this part of the code for undo has not been changed.

```python-traceback
Traceback (most recent call last):
  File "./placementoptimizer.py.py", line 5640, in <module>
    exit(main())
         ^^^^^^
  File "./placementoptimizer.py", line 5634, in main
    run()
  File "./placementoptimizer.py", line 5596, in <lambda>
    run = lambda: undo_remapped(args, state)
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "./placementoptimizer.py", line 5470, in undo_remapped
    source_osdids = {int(osdid) for osdid in args.osds.split(" ")}
                                             ^^^^^^^^^
AttributeError: 'Namespace' object has no attribute 'osds'
```